### PR TITLE
Handle NULL hostptr in conformance image tests

### DIFF
--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -1360,11 +1360,10 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
         {
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
-            unprotImage = create_image_2d( context,
-                                      image_read_write_flags | gMemFlagsToUse,
-                                      imageInfo->format,
-                                      imageInfo->width, imageInfo->height, ( gEnablePitch ? imageInfo->rowPitch : 0 ),
-                                      imageValues, &error );
+            unprotImage = create_image_2d(
+                context, image_read_write_flags | gMemFlagsToUse,
+                imageInfo->format, imageInfo->width, imageInfo->height,
+                (gEnablePitch ? imageInfo->rowPitch : 0), NULL, &error);
         }
         if( error != CL_SUCCESS )
         {

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -320,11 +320,10 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
         }
         else
         {
-            unprotImage = create_image_1d( context,
-                                          image_read_write_flags | gMemFlagsToUse,
-                                          imageInfo->format,
-                                          imageInfo->width, ( gEnablePitch ? imageInfo->rowPitch : 0 ),
-                                          imageValues, NULL, &error );
+            unprotImage = create_image_1d(
+                context, image_read_write_flags | gMemFlagsToUse,
+                imageInfo->format, imageInfo->width,
+                (gEnablePitch ? imageInfo->rowPitch : 0), NULL, NULL, &error);
             if( error != CL_SUCCESS )
             {
                 log_error( "ERROR: Unable to create 1D image of size %d pitch %d (%s)\n", (int)imageInfo->width, (int)imageInfo->rowPitch, IGetErrorString( error ) );

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -387,13 +387,11 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
         }
         else
         {
-            unprotImage = create_image_1d_array(context,
-                                                image_read_write_flags | gMemFlagsToUse,
-                                                imageInfo->format,
-                                                imageInfo->width, imageInfo->arraySize,
-                                                ( gEnablePitch ? imageInfo->rowPitch : 0 ),
-                                                ( gEnablePitch ? imageInfo->slicePitch : 0),
-                                                imageValues, &error);
+            unprotImage = create_image_1d_array(
+                context, image_read_write_flags | gMemFlagsToUse,
+                imageInfo->format, imageInfo->width, imageInfo->arraySize,
+                (gEnablePitch ? imageInfo->rowPitch : 0),
+                (gEnablePitch ? imageInfo->slicePitch : 0), NULL, &error);
 
             if( error != CL_SUCCESS )
             {

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -406,13 +406,11 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
         {
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
-            unprotImage = create_image_2d_array( context,
-                                          image_read_write_flags | gMemFlagsToUse,
-                                          imageInfo->format,
-                                          imageInfo->width, imageInfo->height, imageInfo->arraySize,
-                                          ( gEnablePitch ? imageInfo->rowPitch : 0 ),
-                                          ( gEnablePitch ? imageInfo->slicePitch : 0 ),
-                                          imageValues, &error );
+            unprotImage = create_image_2d_array(
+                context, image_read_write_flags | gMemFlagsToUse,
+                imageInfo->format, imageInfo->width, imageInfo->height,
+                imageInfo->arraySize, (gEnablePitch ? imageInfo->rowPitch : 0),
+                (gEnablePitch ? imageInfo->slicePitch : 0), NULL, &error);
             if( error != CL_SUCCESS )
             {
                 log_error( "ERROR: Unable to create 2D image array of size %d x %d x %d (pitch %d, %d ) (%s)", (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->arraySize, (int)imageInfo->rowPitch, (int)imageInfo->slicePitch, IGetErrorString( error ) );

--- a/test_conformance/images/kernel_read_write/test_read_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_3D.cpp
@@ -390,13 +390,11 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
         // it works just as if no flag is specified, so we just do the same thing either way
         if ( !gTestMipmaps )
         {
-            unprotImage = create_image_3d( context,
-                                          image_read_write_flags | gMemFlagsToUse,
-                                          imageInfo->format,
-                                          imageInfo->width, imageInfo->height, imageInfo->depth,
-                                          ( gEnablePitch ? imageInfo->rowPitch : 0 ),
-                                          ( gEnablePitch ? imageInfo->slicePitch : 0 ),
-                                          imageValues, &error );
+            unprotImage = create_image_3d(
+                context, image_read_write_flags | gMemFlagsToUse,
+                imageInfo->format, imageInfo->width, imageInfo->height,
+                imageInfo->depth, (gEnablePitch ? imageInfo->rowPitch : 0),
+                (gEnablePitch ? imageInfo->slicePitch : 0), NULL, &error);
             if( error != CL_SUCCESS )
             {
                 log_error( "ERROR: Unable to create 3D image of size %d x %d x %d (pitch %d, %d ) (%s)", (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->depth, (int)imageInfo->rowPitch, (int)imageInfo->slicePitch, IGetErrorString( error ) );

--- a/test_conformance/images/kernel_read_write/test_write_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D.cpp
@@ -215,6 +215,13 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
         }
         else // Either CL_MEM_ALLOC_HOST_PTR, CL_MEM_COPY_HOST_PTR or none
         {
+            char *host_ptr = NULL;
+
+            if (gMemFlagsToUse & CL_MEM_COPY_HOST_PTR)
+            {
+                host_ptr = imageValues;
+            }
+
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
             // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
@@ -237,9 +244,12 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
             }
             else
             {
-                unprotImage = create_image_1d( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
-                                              imageInfo->width, 0,
-                                              imageValues, NULL, &error );
+                unprotImage = create_image_1d(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, imageInfo->width, 0, host_ptr, NULL,
+                    &error);
                 if( error != CL_SUCCESS )
                 {
                     log_error( "ERROR: Unable to create 1D image of size %ld pitch %ld (%s, %s)\n", imageInfo->width,

--- a/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
@@ -226,6 +226,13 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
         }
         else // Either CL_MEM_ALLOC_HOST_PTR, CL_MEM_COPY_HOST_PTR or none
         {
+            char *host_ptr = NULL;
+
+            if (gMemFlagsToUse & CL_MEM_COPY_HOST_PTR)
+            {
+                host_ptr = imageValues;
+            }
+
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
             // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
@@ -248,9 +255,12 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
             }
             else
             {
-                unprotImage = create_image_1d_array( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
-                                              imageInfo->width, imageInfo->arraySize, 0, 0,
-                                              imageValues, &error );
+                unprotImage = create_image_1d_array(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, imageInfo->width, imageInfo->arraySize,
+                    0, 0, host_ptr, &error);
                 if( error != CL_SUCCESS )
                 {
                     log_error( "ERROR: Unable to create 1D image array of size %ld x %ld pitch %ld (%s, %s)\n", imageInfo->width, imageInfo->arraySize,

--- a/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
@@ -245,6 +245,13 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
         }
         else // Either CL_MEM_ALLOC_HOST_PTR, CL_MEM_COPY_HOST_PTR or none
         {
+            char *host_ptr = NULL;
+
+            if (gMemFlagsToUse & CL_MEM_COPY_HOST_PTR)
+            {
+                host_ptr = imageValues;
+            }
+
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
             // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
@@ -268,8 +275,12 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
             }
             else
             {
-                unprotImage = create_image_2d_array( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
-                                              imageInfo->width, imageInfo->height, imageInfo->arraySize, 0, 0, imageValues, &error );
+                unprotImage = create_image_2d_array(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, imageInfo->width, imageInfo->height,
+                    imageInfo->arraySize, 0, 0, host_ptr, &error);
                 if( error != CL_SUCCESS )
                 {
                     log_error( "ERROR: Unable to create 2D image array of size %ld x %ld x %ld pitch %ld (%s)\n", imageInfo->width, imageInfo->height, imageInfo->arraySize, imageInfo->rowPitch, IGetErrorString( error ) );

--- a/test_conformance/images/kernel_read_write/test_write_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_3D.cpp
@@ -249,6 +249,13 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
         }
         else // Either CL_MEM_ALLOC_HOST_PTR, CL_MEM_COPY_HOST_PTR or none
         {
+            char *host_ptr = NULL;
+
+            if (gMemFlagsToUse & CL_MEM_COPY_HOST_PTR)
+            {
+                host_ptr = imageValues;
+            }
+
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
             // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
@@ -272,8 +279,12 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
             }
             else
             {
-                unprotImage = create_image_3d( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
-                                              imageInfo->width, imageInfo->height, imageInfo->depth, 0, 0, imageValues, &error );
+                unprotImage = create_image_3d(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, imageInfo->width, imageInfo->height,
+                    imageInfo->depth, 0, 0, host_ptr, &error);
                 if( error != CL_SUCCESS )
                 {
                     log_error( "ERROR: Unable to create 3D image of size %ld x %ld x %ld pitch %ld (%s)\n", imageInfo->width, imageInfo->height, imageInfo->depth, imageInfo->rowPitch, IGetErrorString( error ) );

--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -255,6 +255,13 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
         }
         else // Either CL_MEM_ALLOC_HOST_PTR, CL_MEM_COPY_HOST_PTR or none
         {
+            char *host_ptr = NULL;
+
+            if (gMemFlagsToUse & CL_MEM_COPY_HOST_PTR)
+            {
+                host_ptr = imageValues;
+            }
+
             if( gTestMipmaps )
             {
                 cl_image_desc image_desc = {0};
@@ -288,9 +295,12 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                 // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
                 // it works just as if no flag is specified, so we just do the same thing either way
                 // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
-                unprotImage = create_image_2d( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
-                                          imageInfo->width, imageInfo->height, 0,
-                                          imageValues, &error );
+                unprotImage = create_image_2d(
+                    context,
+                    mem_flag_types[mem_flag_index]
+                        | (gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
+                    imageInfo->format, imageInfo->width, imageInfo->height, 0,
+                    host_ptr, &error);
             }
             if( error != CL_SUCCESS )
             {


### PR DESCRIPTION
As per the spec, clCreateBuffer and clCreateImage return
CL_INVALID_HOST_PTR if host_ptr is NULL
and CL_MEM_USE_HOST_PTR or CL_MEM_COPY_HOST_PTR are set in flags
or if host_ptr is not NULL
but CL_MEM_USE_HOST_PTR or CL_MEM_COPY_HOST_PTR are not set in flags."

Host pointer should be NULL when USE/COPY_HOST_PTR is not set in flags.