### PR TITLE
Origin/test imagedim new

### DIFF
--- a/test_conformance/basic/test_imagedim.cpp
+++ b/test_conformance/basic/test_imagedim.cpp
@@ -38,29 +38,29 @@ static const char *image_dim_kernel_code =
 "}\n";
 
 
-static unsigned char *
-generate_8888_image(int w, int h, MTdata d)
+static unsigned char *generate_8888_image(size_t w, size_t h, MTdata d)
 {
     unsigned char *ptr =
         (unsigned char *)malloc(sizeof(unsigned char) * 4 * w * h);
-    unsigned int i;
+    size_t i;
     if (ptr == NULL)
     {
         return ptr;
     }
 
-    for (i=0; i<w*h*4; i++)
+    for (i = 0; i < w * h * 4; i++)
+    {
         ptr[i] = (unsigned char)genrand_int32(d);
-
+    }
     return ptr;
 }
 
-static int
-verify_8888_image(unsigned char *image, unsigned char *outptr, int w, int h)
+static int verify_8888_image(unsigned char *image, unsigned char *outptr,
+                             size_t w, size_t h)
 {
-    int     i;
+    size_t i;
 
-    for (i=0; i<w*h; i++)
+    for (i = 0; i < w * h; i++)
     {
         if (outptr[i] != image[i])
             return -1;
@@ -73,18 +73,18 @@ verify_8888_image(unsigned char *image, unsigned char *outptr, int w, int h)
 int
 test_imagedim_pow2(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems)
 {
-    cl_mem            streams[2];
-    cl_image_format    img_format;
-    unsigned char    *input_ptr, *output_ptr;
-    cl_program        program;
-    cl_kernel        kernel;
-    size_t    threads[2];
-     cl_ulong    max_mem_size;
-    int                img_width, max_img_width;
-    int                img_height, max_img_height;
-    int                max_img_dim;
-    int                i, j, i2, j2, err=0;
-    size_t            max_image2d_width, max_image2d_height;
+    cl_mem streams[2];
+    cl_image_format img_format;
+    unsigned char *input_ptr, *output_ptr;
+    cl_program program;
+    cl_kernel kernel;
+    size_t threads[2];
+    cl_ulong max_mem_size;
+    size_t img_width, max_img_width;
+    size_t img_height, max_img_height;
+    size_t max_img_dim;
+    int i, j, i2, j2, err = 0;
+    size_t max_image2d_width, max_image2d_height;
     int total_errors = 0;
     MTdata  d;
 
@@ -125,15 +125,15 @@ test_imagedim_pow2(cl_device_id device, cl_context context, cl_command_queue que
     cl_sampler sampler = clCreateSampler(context, CL_FALSE, CL_ADDRESS_CLAMP_TO_EDGE, CL_FILTER_NEAREST, &err);
     test_error(err, "clCreateSampler failed");
 
-    max_img_width = (int)max_image2d_width;
-    max_img_height = (int)max_image2d_height;
+    max_img_width = max_image2d_width;
+    max_img_height = max_image2d_height;
 
     // determine max image dim we can allocate - assume RGBA image, 4 bytes per pixel,
   //  and we want to consume 1/4 of global memory (this is the minimum required to be
   //  supported by the spec)
     max_mem_size /= 4; // use 1/4
     max_mem_size /= 4; // 4 bytes per pixel
-    max_img_dim = (int)sqrt((double)max_mem_size);
+    max_img_dim = (size_t)sqrt((double)max_mem_size);
     // convert to a power of 2
     {
         unsigned int    n = (unsigned int)max_img_dim;
@@ -143,7 +143,7 @@ test_imagedim_pow2(cl_device_id device, cl_context context, cl_command_queue que
         while (m > n)
             m >>= 1;
 
-        max_img_dim = (int)m;
+        max_img_dim = m;
     }
 
     if (max_img_width > max_img_dim)
@@ -155,6 +155,7 @@ test_imagedim_pow2(cl_device_id device, cl_context context, cl_command_queue que
                 max_img_width, max_img_height, (max_img_width*max_img_height*4)/(1024.0*1024.0));
 
     d = init_genrand( gRandomSeed );
+    log_info("Initialized data\n");
     input_ptr = generate_8888_image(max_img_width, max_img_height, d);
     if (input_ptr == NULL)
     {
@@ -173,10 +174,10 @@ test_imagedim_pow2(cl_device_id device, cl_context context, cl_command_queue que
     }
 
     // test power of 2 width, height starting at 1 to 4K
-    for (i=1,i2=0; i<=max_img_height; i<<=1,i2++)
+    for (i = 1, i2 = 0; i <= max_img_height; i <<= 1, i2++)
     {
         img_height = (1 << i2);
-        for (j=1,j2=0; j<=max_img_width; j<<=1,j2++)
+        for (j = 1, j2 = 0; j <= max_img_width; j <<= 1, j2++)
         {
             img_width = (1 << j2);
 
@@ -293,18 +294,18 @@ test_imagedim_pow2(cl_device_id device, cl_context context, cl_command_queue que
 int
 test_imagedim_non_pow2(cl_device_id device, cl_context context, cl_command_queue queue, int n_elems)
 {
-    cl_mem            streams[2];
-    cl_image_format    img_format;
-    unsigned char    *input_ptr, *output_ptr;
-    cl_program        program;
-    cl_kernel        kernel;
-    size_t    threads[2], local_threads[2];
-    cl_ulong    max_mem_size;
-    int                img_width, max_img_width;
-    int                img_height, max_img_height;
-    int                max_img_dim;
-    int                i, j, i2, j2, err=0;
-    size_t            max_image2d_width, max_image2d_height;
+    cl_mem streams[2];
+    cl_image_format img_format;
+    unsigned char *input_ptr, *output_ptr;
+    cl_program program;
+    cl_kernel kernel;
+    size_t threads[2], local_threads[2];
+    cl_ulong max_mem_size;
+    size_t img_width, max_img_width;
+    size_t img_height, max_img_height;
+    size_t max_img_dim;
+    int i, j, i2, j2, err = 0;
+    size_t max_image2d_width, max_image2d_height;
     int total_errors = 0;
     size_t max_local_workgroup_size[3];
     MTdata d;
@@ -401,7 +402,7 @@ test_imagedim_non_pow2(cl_device_id device, cl_context context, cl_command_queue
     }
 
     int plus_minus;
-    for (plus_minus=0; plus_minus < 3; plus_minus++)
+    for (plus_minus = 0; plus_minus < 3; plus_minus++)
     {
 
     // test power of 2 width, height starting at 1 to 4K
@@ -412,8 +413,8 @@ test_imagedim_non_pow2(cl_device_id device, cl_context context, cl_command_queue
             {
                 img_width = (1 << j2);
 
-                int effective_img_height = img_height;
-                int effective_img_width = img_width;
+                size_t effective_img_height = img_height;
+                size_t effective_img_width = img_width;
 
                 local_threads[0] = 1;
                 local_threads[1] = 1;

--- a/test_conformance/basic/test_imagedim.cpp
+++ b/test_conformance/basic/test_imagedim.cpp
@@ -40,18 +40,14 @@ static const char *image_dim_kernel_code =
 
 static unsigned char *generate_8888_image(size_t w, size_t h, MTdata d)
 {
-    unsigned char *ptr =
-        (unsigned char *)malloc(sizeof(unsigned char) * 4 * w * h);
+    unsigned char *ptr = new unsigned char[sizeof(unsigned char) * 4 * w * h];
     size_t i;
-    if (ptr == NULL)
-    {
-        return ptr;
-    }
 
     for (i = 0; i < w * h * 4; i++)
     {
         ptr[i] = (unsigned char)genrand_int32(d);
     }
+
     return ptr;
 }
 
@@ -157,21 +153,8 @@ test_imagedim_pow2(cl_device_id device, cl_context context, cl_command_queue que
     d = init_genrand( gRandomSeed );
     log_info("Initialized data\n");
     input_ptr = generate_8888_image(max_img_width, max_img_height, d);
-    if (input_ptr == NULL)
-    {
-        log_error("Malloc returned input_ptr as NULL\n");
-        free_mtdata(d);
-        return -1;
-    }
 
-    output_ptr = (unsigned char*)malloc(sizeof(unsigned char) * 4 * max_img_width * max_img_height);
-    if (output_ptr == NULL)
-    {
-        log_error("Malloc returned output_ptr as NULL\n");
-        free(input_ptr);
-        free_mtdata(d);
-        return -1;
-    }
+    output_ptr = new unsigned char[4 * max_img_width * max_img_height];
 
     // test power of 2 width, height starting at 1 to 4K
     for (i = 1, i2 = 0; i <= max_img_height; i <<= 1, i2++)
@@ -189,8 +172,8 @@ test_imagedim_pow2(cl_device_id device, cl_context context, cl_command_queue que
             if (!streams[0])
             {
                 log_error("create_image_2d failed.  width = %d, height = %d\n", img_width, img_height);
-                free(input_ptr);
-                free(output_ptr);
+                delete[] input_ptr;
+                delete[] output_ptr;
                 free_mtdata(d);
                 return -1;
             }
@@ -203,8 +186,8 @@ test_imagedim_pow2(cl_device_id device, cl_context context, cl_command_queue que
             {
                 log_error("create_image_2d failed.  width = %d, height = %d\n", img_width, img_height);
                 clReleaseMemObject(streams[0]);
-                free(input_ptr);
-                free(output_ptr);
+                delete[] input_ptr;
+                delete[] output_ptr;
                 free_mtdata(d);
                 return -1;
             }
@@ -217,8 +200,8 @@ test_imagedim_pow2(cl_device_id device, cl_context context, cl_command_queue que
                 log_error("clWriteImage failed\n");
                 clReleaseMemObject(streams[0]);
                 clReleaseMemObject(streams[1]);
-                free(input_ptr);
-                free(output_ptr);
+                delete[] input_ptr;
+                delete[] output_ptr;
                 free_mtdata(d);
                 return -1;
             }
@@ -231,8 +214,8 @@ test_imagedim_pow2(cl_device_id device, cl_context context, cl_command_queue que
                 log_error("clSetKernelArgs failed\n");
                 clReleaseMemObject(streams[0]);
                 clReleaseMemObject(streams[1]);
-                free(input_ptr);
-                free(output_ptr);
+                delete[] input_ptr;
+                delete[] output_ptr;
                 free_mtdata(d);
                 return -1;
             }
@@ -248,8 +231,8 @@ test_imagedim_pow2(cl_device_id device, cl_context context, cl_command_queue que
                             img_width, img_height);
                 clReleaseMemObject(streams[0]);
                 clReleaseMemObject(streams[1]);
-                free(input_ptr);
-                free(output_ptr);
+                delete[] input_ptr;
+                delete[] output_ptr;
                 free_mtdata(d);
                 return -1;
             }
@@ -261,8 +244,8 @@ test_imagedim_pow2(cl_device_id device, cl_context context, cl_command_queue que
                             img_width, img_height);
                 clReleaseMemObject(streams[0]);
                 clReleaseMemObject(streams[1]);
-                free(input_ptr);
-                free(output_ptr);
+                delete[] input_ptr;
+                delete[] output_ptr;
                 free_mtdata(d);
                 return -1;
             }
@@ -279,8 +262,8 @@ test_imagedim_pow2(cl_device_id device, cl_context context, cl_command_queue que
     }
 
     // cleanup
-    free(input_ptr);
-    free(output_ptr);
+    delete[] input_ptr;
+    delete[] output_ptr;
     free_mtdata(d);
     clReleaseSampler(sampler);
     clReleaseKernel(kernel);
@@ -385,21 +368,7 @@ test_imagedim_non_pow2(cl_device_id device, cl_context context, cl_command_queue
 
     d = init_genrand( gRandomSeed );
     input_ptr = generate_8888_image(max_img_width, max_img_height, d);
-    if (input_ptr == NULL)
-    {
-        log_error("Malloc returned input_ptr as NULL\n");
-        free_mtdata(d);
-        return -1;
-    }
-
-    output_ptr = (unsigned char*)malloc(sizeof(unsigned char) * 4 * max_img_width * max_img_height);
-    if (output_ptr == NULL)
-    {
-        log_error("Malloc returned output_ptr as NULL\n");
-        free(input_ptr);
-        free_mtdata(d);
-        return -1;
-    }
+    output_ptr = new unsigned char[4 * max_img_width * max_img_height];
 
     int plus_minus;
     for (plus_minus = 0; plus_minus < 3; plus_minus++)
@@ -448,8 +417,8 @@ test_imagedim_non_pow2(cl_device_id device, cl_context context, cl_command_queue
                 if (!streams[0])
                 {
                     log_error("create_image_2d failed.  width = %d, height = %d\n", effective_img_width, effective_img_height);
-                    free(input_ptr);
-                    free(output_ptr);
+                    delete[] input_ptr;
+                    delete[] output_ptr;
                     free_mtdata(d);
                     return -1;
                 }
@@ -462,8 +431,8 @@ test_imagedim_non_pow2(cl_device_id device, cl_context context, cl_command_queue
                 {
                     log_error("create_image_2d failed.  width = %d, height = %d\n", effective_img_width, effective_img_height);
                     clReleaseMemObject(streams[0]);
-                    free(input_ptr);
-                    free(output_ptr);
+                    delete[] input_ptr;
+                    delete[] output_ptr;
                     free_mtdata(d);
                     return -1;
                 }
@@ -476,8 +445,8 @@ test_imagedim_non_pow2(cl_device_id device, cl_context context, cl_command_queue
                     log_error("clWriteImage failed\n");
                     clReleaseMemObject(streams[0]);
                     clReleaseMemObject(streams[1]);
-                    free(input_ptr);
-                    free(output_ptr);
+                    delete[] input_ptr;
+                    delete[] output_ptr;
                     free_mtdata(d);
                     return -1;
                 }
@@ -490,8 +459,8 @@ test_imagedim_non_pow2(cl_device_id device, cl_context context, cl_command_queue
                     log_error("clSetKernelArgs failed\n");
                     clReleaseMemObject(streams[0]);
                     clReleaseMemObject(streams[1]);
-                    free(input_ptr);
-                    free(output_ptr);
+                    delete[] input_ptr;
+                    delete[] output_ptr;
                     free_mtdata(d);
                     return -1;
                 }
@@ -508,8 +477,8 @@ test_imagedim_non_pow2(cl_device_id device, cl_context context, cl_command_queue
                                 effective_img_width, effective_img_height, (int)local_threads[0], (int)local_threads[1]);
                     clReleaseMemObject(streams[0]);
                     clReleaseMemObject(streams[1]);
-                    free(input_ptr);
-                    free(output_ptr);
+                    delete[] input_ptr;
+                    delete[] output_ptr;
                     free_mtdata(d);
                     return -1;
                 }
@@ -521,8 +490,8 @@ test_imagedim_non_pow2(cl_device_id device, cl_context context, cl_command_queue
                                 effective_img_width, effective_img_height, (int)local_threads[0], (int)local_threads[1]);
                     clReleaseMemObject(streams[0]);
                     clReleaseMemObject(streams[1]);
-                    free(input_ptr);
-                    free(output_ptr);
+                    delete[] input_ptr;
+                    delete[] output_ptr;
                     free_mtdata(d);
                     return -1;
                 }
@@ -540,15 +509,15 @@ test_imagedim_non_pow2(cl_device_id device, cl_context context, cl_command_queue
 
   }
 
-    // cleanup
-    free(input_ptr);
-    free(output_ptr);
-    free_mtdata(d);
-    clReleaseSampler(sampler);
-    clReleaseKernel(kernel);
-    clReleaseProgram(program);
+  // cleanup
+  delete[] input_ptr;
+  delete[] output_ptr;
+  free_mtdata(d);
+  clReleaseSampler(sampler);
+  clReleaseKernel(kernel);
+  clReleaseProgram(program);
 
-    return total_errors;
+  return total_errors;
 }
 
 


### PR DESCRIPTION
Fixes for test_basic imagedim buffer overflow

Use size_t instead of int for imagedim

The size calculation for image with larger dimensions
is overflowing with int values.
Change image dim variables to use size_t
to avoid overflow.
While at it, fix formatting at various places.

 Use new instead of malloc in test imagedim

Use new and delete in place of malloc
and free through test_basic imagedim
to avoid NULL pointer checks.