### PR TITLE
Move cl_mem_flag and host_ptr check to ImageHelper

### DIFF
--- a/test_common/harness/clImageHelper.h
+++ b/test_common/harness/clImageHelper.h
@@ -37,6 +37,11 @@ static inline cl_mem create_image_2d(cl_context context, cl_mem_flags flags,
 {
     cl_mem mImage = NULL;
 
+    if (!(flags & (CL_MEM_USE_HOST_PTR | CL_MEM_COPY_HOST_PTR)))
+    {
+        host_ptr = NULL;
+    }
+
 #ifdef CL_VERSION_1_2
     cl_image_desc image_desc_dest;
     image_desc_dest.image_type = CL_MEM_OBJECT_IMAGE2D;
@@ -119,6 +124,11 @@ static inline cl_mem create_image_3d(cl_context context, cl_mem_flags flags,
 {
     cl_mem mImage;
 
+    if (!(flags & (CL_MEM_USE_HOST_PTR | CL_MEM_COPY_HOST_PTR)))
+    {
+        host_ptr = NULL;
+    }
+
 #ifdef CL_VERSION_1_2
     cl_image_desc image_desc;
     image_desc.image_type = CL_MEM_OBJECT_IMAGE3D;
@@ -166,6 +176,11 @@ create_image_2d_array(cl_context context, cl_mem_flags flags,
 {
     cl_mem mImage;
 
+    if (!(flags & (CL_MEM_USE_HOST_PTR | CL_MEM_COPY_HOST_PTR)))
+    {
+        host_ptr = NULL;
+    }
+
     cl_image_desc image_desc;
     image_desc.image_type = CL_MEM_OBJECT_IMAGE2D_ARRAY;
     image_desc.image_width = image_width;
@@ -195,6 +210,11 @@ static inline cl_mem create_image_1d_array(
     size_t image_slice_pitch, void *host_ptr, cl_int *errcode_ret)
 {
     cl_mem mImage;
+
+    if (!(flags & (CL_MEM_USE_HOST_PTR | CL_MEM_COPY_HOST_PTR)))
+    {
+        host_ptr = NULL;
+    }
 
     cl_image_desc image_desc;
     image_desc.image_type = CL_MEM_OBJECT_IMAGE1D_ARRAY;
@@ -226,6 +246,11 @@ static inline cl_mem create_image_1d(cl_context context, cl_mem_flags flags,
                                      cl_int *errcode_ret)
 {
     cl_mem mImage;
+
+    if (!(flags & (CL_MEM_USE_HOST_PTR | CL_MEM_COPY_HOST_PTR)))
+    {
+        host_ptr = NULL;
+    }
 
     cl_image_desc image_desc;
     image_desc.image_type =

--- a/test_conformance/images/kernel_read_write/test_iterations.cpp
+++ b/test_conformance/images/kernel_read_write/test_iterations.cpp
@@ -1360,10 +1360,11 @@ int test_read_image_2D( cl_context context, cl_command_queue queue, cl_kernel ke
         {
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
-            unprotImage = create_image_2d(
-                context, image_read_write_flags | gMemFlagsToUse,
-                imageInfo->format, imageInfo->width, imageInfo->height,
-                (gEnablePitch ? imageInfo->rowPitch : 0), NULL, &error);
+            unprotImage = create_image_2d( context,
+                                      image_read_write_flags | gMemFlagsToUse,
+                                      imageInfo->format,
+                                      imageInfo->width, imageInfo->height, ( gEnablePitch ? imageInfo->rowPitch : 0 ),
+                                      imageValues, &error );
         }
         if( error != CL_SUCCESS )
         {

--- a/test_conformance/images/kernel_read_write/test_read_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D.cpp
@@ -320,10 +320,11 @@ int test_read_image_1D( cl_context context, cl_command_queue queue, cl_kernel ke
         }
         else
         {
-            unprotImage = create_image_1d(
-                context, image_read_write_flags | gMemFlagsToUse,
-                imageInfo->format, imageInfo->width,
-                (gEnablePitch ? imageInfo->rowPitch : 0), NULL, NULL, &error);
+            unprotImage = create_image_1d( context,
+                                          image_read_write_flags | gMemFlagsToUse,
+                                          imageInfo->format,
+                                          imageInfo->width, ( gEnablePitch ? imageInfo->rowPitch : 0 ),
+                                          imageValues, NULL, &error );
             if( error != CL_SUCCESS )
             {
                 log_error( "ERROR: Unable to create 1D image of size %d pitch %d (%s)\n", (int)imageInfo->width, (int)imageInfo->rowPitch, IGetErrorString( error ) );

--- a/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_1D_array.cpp
@@ -387,11 +387,13 @@ int test_read_image_1D_array( cl_context context, cl_command_queue queue, cl_ker
         }
         else
         {
-            unprotImage = create_image_1d_array(
-                context, image_read_write_flags | gMemFlagsToUse,
-                imageInfo->format, imageInfo->width, imageInfo->arraySize,
-                (gEnablePitch ? imageInfo->rowPitch : 0),
-                (gEnablePitch ? imageInfo->slicePitch : 0), NULL, &error);
+            unprotImage = create_image_1d_array(context,
+                                                image_read_write_flags | gMemFlagsToUse,
+                                                imageInfo->format,
+                                                imageInfo->width, imageInfo->arraySize,
+                                                ( gEnablePitch ? imageInfo->rowPitch : 0 ),
+                                                ( gEnablePitch ? imageInfo->slicePitch : 0),
+                                                imageValues, &error);
 
             if( error != CL_SUCCESS )
             {

--- a/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_2D_array.cpp
@@ -406,11 +406,13 @@ int test_read_image_2D_array( cl_context context, cl_command_queue queue, cl_ker
         {
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
-            unprotImage = create_image_2d_array(
-                context, image_read_write_flags | gMemFlagsToUse,
-                imageInfo->format, imageInfo->width, imageInfo->height,
-                imageInfo->arraySize, (gEnablePitch ? imageInfo->rowPitch : 0),
-                (gEnablePitch ? imageInfo->slicePitch : 0), NULL, &error);
+            unprotImage = create_image_2d_array( context,
+                                          image_read_write_flags | gMemFlagsToUse,
+                                          imageInfo->format,
+                                          imageInfo->width, imageInfo->height, imageInfo->arraySize,
+                                          ( gEnablePitch ? imageInfo->rowPitch : 0 ),
+                                          ( gEnablePitch ? imageInfo->slicePitch : 0 ),
+                                          imageValues, &error );
             if( error != CL_SUCCESS )
             {
                 log_error( "ERROR: Unable to create 2D image array of size %d x %d x %d (pitch %d, %d ) (%s)", (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->arraySize, (int)imageInfo->rowPitch, (int)imageInfo->slicePitch, IGetErrorString( error ) );

--- a/test_conformance/images/kernel_read_write/test_read_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_read_3D.cpp
@@ -390,11 +390,13 @@ int test_read_image_3D( cl_context context, cl_command_queue queue, cl_kernel ke
         // it works just as if no flag is specified, so we just do the same thing either way
         if ( !gTestMipmaps )
         {
-            unprotImage = create_image_3d(
-                context, image_read_write_flags | gMemFlagsToUse,
-                imageInfo->format, imageInfo->width, imageInfo->height,
-                imageInfo->depth, (gEnablePitch ? imageInfo->rowPitch : 0),
-                (gEnablePitch ? imageInfo->slicePitch : 0), NULL, &error);
+            unprotImage = create_image_3d( context,
+                                          image_read_write_flags | gMemFlagsToUse,
+                                          imageInfo->format,
+                                          imageInfo->width, imageInfo->height, imageInfo->depth,
+                                          ( gEnablePitch ? imageInfo->rowPitch : 0 ),
+                                          ( gEnablePitch ? imageInfo->slicePitch : 0 ),
+                                          imageValues, &error );
             if( error != CL_SUCCESS )
             {
                 log_error( "ERROR: Unable to create 3D image of size %d x %d x %d (pitch %d, %d ) (%s)", (int)imageInfo->width, (int)imageInfo->height, (int)imageInfo->depth, (int)imageInfo->rowPitch, (int)imageInfo->slicePitch, IGetErrorString( error ) );

--- a/test_conformance/images/kernel_read_write/test_write_1D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D.cpp
@@ -215,13 +215,6 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
         }
         else // Either CL_MEM_ALLOC_HOST_PTR, CL_MEM_COPY_HOST_PTR or none
         {
-            char *host_ptr = NULL;
-
-            if (gMemFlagsToUse & CL_MEM_COPY_HOST_PTR)
-            {
-                host_ptr = imageValues;
-            }
-
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
             // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
@@ -244,12 +237,9 @@ int test_write_image_1D( cl_device_id device, cl_context context, cl_command_que
             }
             else
             {
-                unprotImage = create_image_1d(
-                    context,
-                    mem_flag_types[mem_flag_index]
-                        | (gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
-                    imageInfo->format, imageInfo->width, 0, host_ptr, NULL,
-                    &error);
+                unprotImage = create_image_1d( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
+                                              imageInfo->width, 0,
+                                              imageValues, NULL, &error );
                 if( error != CL_SUCCESS )
                 {
                     log_error( "ERROR: Unable to create 1D image of size %ld pitch %ld (%s, %s)\n", imageInfo->width,

--- a/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_1D_array.cpp
@@ -226,13 +226,6 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
         }
         else // Either CL_MEM_ALLOC_HOST_PTR, CL_MEM_COPY_HOST_PTR or none
         {
-            char *host_ptr = NULL;
-
-            if (gMemFlagsToUse & CL_MEM_COPY_HOST_PTR)
-            {
-                host_ptr = imageValues;
-            }
-
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
             // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
@@ -255,12 +248,9 @@ int test_write_image_1D_array( cl_device_id device, cl_context context, cl_comma
             }
             else
             {
-                unprotImage = create_image_1d_array(
-                    context,
-                    mem_flag_types[mem_flag_index]
-                        | (gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
-                    imageInfo->format, imageInfo->width, imageInfo->arraySize,
-                    0, 0, host_ptr, &error);
+                unprotImage = create_image_1d_array( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
+                                              imageInfo->width, imageInfo->arraySize, 0, 0,
+                                              imageValues, &error );
                 if( error != CL_SUCCESS )
                 {
                     log_error( "ERROR: Unable to create 1D image array of size %ld x %ld pitch %ld (%s, %s)\n", imageInfo->width, imageInfo->arraySize,

--- a/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_2D_array.cpp
@@ -245,13 +245,6 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
         }
         else // Either CL_MEM_ALLOC_HOST_PTR, CL_MEM_COPY_HOST_PTR or none
         {
-            char *host_ptr = NULL;
-
-            if (gMemFlagsToUse & CL_MEM_COPY_HOST_PTR)
-            {
-                host_ptr = imageValues;
-            }
-
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
             // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
@@ -275,12 +268,8 @@ int test_write_image_2D_array( cl_device_id device, cl_context context, cl_comma
             }
             else
             {
-                unprotImage = create_image_2d_array(
-                    context,
-                    mem_flag_types[mem_flag_index]
-                        | (gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
-                    imageInfo->format, imageInfo->width, imageInfo->height,
-                    imageInfo->arraySize, 0, 0, host_ptr, &error);
+                unprotImage = create_image_2d_array( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
+                                              imageInfo->width, imageInfo->height, imageInfo->arraySize, 0, 0, imageValues, &error );
                 if( error != CL_SUCCESS )
                 {
                     log_error( "ERROR: Unable to create 2D image array of size %ld x %ld x %ld pitch %ld (%s)\n", imageInfo->width, imageInfo->height, imageInfo->arraySize, imageInfo->rowPitch, IGetErrorString( error ) );

--- a/test_conformance/images/kernel_read_write/test_write_3D.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_3D.cpp
@@ -249,13 +249,6 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
         }
         else // Either CL_MEM_ALLOC_HOST_PTR, CL_MEM_COPY_HOST_PTR or none
         {
-            char *host_ptr = NULL;
-
-            if (gMemFlagsToUse & CL_MEM_COPY_HOST_PTR)
-            {
-                host_ptr = imageValues;
-            }
-
             // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
             // it works just as if no flag is specified, so we just do the same thing either way
             // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
@@ -279,12 +272,8 @@ int test_write_image_3D( cl_device_id device, cl_context context, cl_command_que
             }
             else
             {
-                unprotImage = create_image_3d(
-                    context,
-                    mem_flag_types[mem_flag_index]
-                        | (gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
-                    imageInfo->format, imageInfo->width, imageInfo->height,
-                    imageInfo->depth, 0, 0, host_ptr, &error);
+                unprotImage = create_image_3d( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
+                                              imageInfo->width, imageInfo->height, imageInfo->depth, 0, 0, imageValues, &error );
                 if( error != CL_SUCCESS )
                 {
                     log_error( "ERROR: Unable to create 3D image of size %ld x %ld x %ld pitch %ld (%s)\n", imageInfo->width, imageInfo->height, imageInfo->depth, imageInfo->rowPitch, IGetErrorString( error ) );

--- a/test_conformance/images/kernel_read_write/test_write_image.cpp
+++ b/test_conformance/images/kernel_read_write/test_write_image.cpp
@@ -255,13 +255,6 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
         }
         else // Either CL_MEM_ALLOC_HOST_PTR, CL_MEM_COPY_HOST_PTR or none
         {
-            char *host_ptr = NULL;
-
-            if (gMemFlagsToUse & CL_MEM_COPY_HOST_PTR)
-            {
-                host_ptr = imageValues;
-            }
-
             if( gTestMipmaps )
             {
                 cl_image_desc image_desc = {0};
@@ -295,12 +288,9 @@ int test_write_image( cl_device_id device, cl_context context, cl_command_queue 
                 // Note: if ALLOC_HOST_PTR is used, the driver allocates memory that can be accessed by the host, but otherwise
                 // it works just as if no flag is specified, so we just do the same thing either way
                 // Note: if the flags is really CL_MEM_COPY_HOST_PTR, we want to remove it, because we don't want to copy any incoming data
-                unprotImage = create_image_2d(
-                    context,
-                    mem_flag_types[mem_flag_index]
-                        | (gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR)),
-                    imageInfo->format, imageInfo->width, imageInfo->height, 0,
-                    host_ptr, &error);
+                unprotImage = create_image_2d( context, mem_flag_types[mem_flag_index] | ( gMemFlagsToUse & ~(CL_MEM_COPY_HOST_PTR) ), imageInfo->format,
+                                          imageInfo->width, imageInfo->height, 0,
+                                          imageValues, &error );
             }
             if( error != CL_SUCCESS )
             {


### PR DESCRIPTION
 Add a check to see if cl_mem_flag has
 USE_HOST_PTR or COPY_HOST_PTR.
 Override host_ptr with NULL if none of them
 are specified.

Revert earlier changes spread over multiple files 
under images/kernel_read_write.
