### PR TITLE
    Fix warnings around getHandle API and macros

### DIFF
--- a/test_conformance/vulkan/test_vulkan_api_consistency.cpp
+++ b/test_conformance/vulkan/test_vulkan_api_consistency.cpp
@@ -74,13 +74,7 @@ int test_consistency_external_buffer(cl_device_id deviceID,
     };
     cl_external_memory_handle_type_khr type;
     switch (vkExternalMemoryHandleType) {
-    case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD:
-        fd = (int)vkDeviceMem->getHandle(vkExternalMemoryHandleType);
-        type = CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR;
-        errNum = check_external_memory_handle_type(devList[0], type);
-        extMemProperties.push_back((cl_mem_properties)type);
-        extMemProperties.push_back((cl_mem_properties)fd);
-        break;
+#ifdef _WIN32
     case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_NT:
         handle = vkDeviceMem->getHandle(vkExternalMemoryHandleType);
         type = CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR;
@@ -95,6 +89,15 @@ int test_consistency_external_buffer(cl_device_id deviceID,
         extMemProperties.push_back((cl_mem_properties)type);
         extMemProperties.push_back((cl_mem_properties)handle);
         break;
+#else
+    case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD:
+        fd = (int)vkDeviceMem->getHandle(vkExternalMemoryHandleType);
+        type = CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR;
+        errNum = check_external_memory_handle_type(devList[0], type);
+        extMemProperties.push_back((cl_mem_properties)type);
+        extMemProperties.push_back((cl_mem_properties)fd);
+        break;
+#endif
     default:
         errNum = TEST_FAIL;
         log_error("Unsupported external memory handle type \n");
@@ -221,12 +224,7 @@ int test_consistency_external_image(cl_device_id deviceID,
         (cl_mem_properties)CL_DEVICE_HANDLE_LIST_END_KHR,
     };
     switch (vkExternalMemoryHandleType) {
-    case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD:
-        fd = (int)vkDeviceMem->getHandle(vkExternalMemoryHandleType);
-        errNum = check_external_memory_handle_type(devList[0], CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
-        extMemProperties.push_back((cl_mem_properties)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
-        extMemProperties.push_back((cl_mem_properties)fd);
-        break;
+#ifdef _WIN32
     case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_NT:
         handle = vkDeviceMem->getHandle(vkExternalMemoryHandleType);
         errNum = check_external_memory_handle_type(devList[0], CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR);
@@ -239,6 +237,14 @@ int test_consistency_external_image(cl_device_id deviceID,
         extMemProperties.push_back((cl_mem_properties)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR);
         extMemProperties.push_back((cl_mem_properties)handle);
         break;
+#else
+    case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD:
+        fd = (int)vkDeviceMem->getHandle(vkExternalMemoryHandleType);
+        errNum = check_external_memory_handle_type(devList[0], CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
+        extMemProperties.push_back((cl_mem_properties)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
+        extMemProperties.push_back((cl_mem_properties)fd);
+        break;
+#endif
     default:
         errNum = TEST_FAIL;
         log_error("Unsupported external memory handle type \n");
@@ -388,16 +394,7 @@ int test_consistency_external_semaphore(cl_device_id deviceID,
         (cl_semaphore_properties_khr)CL_SEMAPHORE_TYPE_BINARY_KHR,
     };
     switch (vkExternalSemaphoreHandleType) {
-        case VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD:
-            log_info(" Opaque file descriptors are not supported on Windows\n");
-            fd1 = (int)vkVk2Clsemaphore.getHandle(vkExternalSemaphoreHandleType);
-            fd2 = (int)vkCl2Vksemaphore.getHandle(vkExternalSemaphoreHandleType);
-            errNum = check_external_semaphore_handle_type(devList[0], CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR);
-            sema_props1.push_back((cl_semaphore_properties_khr)CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR);
-            sema_props1.push_back((cl_semaphore_properties_khr)fd1);
-            sema_props2.push_back((cl_semaphore_properties_khr)CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR);
-            sema_props2.push_back((cl_semaphore_properties_khr)fd2);
-            break;
+#ifdef _WIN32
         case VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_NT:
             log_info(" Opaque NT handles are only supported on Windows\n");
             handle1 = vkVk2Clsemaphore.getHandle(vkExternalSemaphoreHandleType);
@@ -418,6 +415,18 @@ int test_consistency_external_semaphore(cl_device_id deviceID,
             sema_props2.push_back((cl_semaphore_properties_khr)CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR);
             sema_props2.push_back((cl_semaphore_properties_khr)handle2);
             break;
+#else
+        case VULKAN_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD:
+            log_info(" Opaque file descriptors are not supported on Windows\n");
+            fd1 = (int)vkVk2Clsemaphore.getHandle(vkExternalSemaphoreHandleType);
+            fd2 = (int)vkCl2Vksemaphore.getHandle(vkExternalSemaphoreHandleType);
+            errNum = check_external_semaphore_handle_type(devList[0], CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR);
+            sema_props1.push_back((cl_semaphore_properties_khr)CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR);
+            sema_props1.push_back((cl_semaphore_properties_khr)fd1);
+            sema_props2.push_back((cl_semaphore_properties_khr)CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR);
+            sema_props2.push_back((cl_semaphore_properties_khr)fd2);
+            break;
+#endif
         default:
             log_error("Unsupported external memory handle type\n");
             break;

--- a/test_conformance/vulkan/test_vulkan_platform_device_info.cpp
+++ b/test_conformance/vulkan/test_vulkan_platform_device_info.cpp
@@ -42,7 +42,7 @@ int test_platform_info(cl_device_id deviceID,
     errNum = clGetPlatformIDs(0, NULL, &num_platforms);
     test_error(errNum, "clGetPlatformIDs (getting count) failed");
 
-    platforms = malloc(num_platforms * sizeof(cl_platform_id));
+    platforms = (cl_platform_id *)malloc(num_platforms * sizeof(cl_platform_id));
     if (!platforms) {
         printf("error allocating memory\n");
         exit(1);

--- a/test_conformance/vulkan/vulkan_interop_common/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/vulkan/vulkan_interop_common/opencl_vulkan_wrapper.cpp
@@ -1,3 +1,4 @@
+#include <CL/cl_ext.h>
 #include "opencl_vulkan_wrapper.hpp"
 #include "vulkan_wrapper.hpp"
 #include "harness/errorHelpers.h"
@@ -379,16 +380,16 @@ cl_int getCLImageInfoFromVkImageInfo(const VkImageCreateInfo *VulkanImageCreateI
     return result;
 }
 
-cl_int check_external_memory_handle_type(cl_device_id deviceID, cl_external_mem_handle_type_khr requiredHandleType)
+cl_int check_external_memory_handle_type(cl_device_id deviceID, cl_external_memory_handle_type_khr requiredHandleType)
 {
     unsigned int i;
-    cl_external_mem_handle_type_khr* handle_type;
+    cl_external_memory_handle_type_khr* handle_type;
     size_t handle_type_size = 0;
 
     cl_int errNum = CL_SUCCESS;
 
     errNum = clGetDeviceInfo(deviceID, CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR, 0, NULL, &handle_type_size);
-    handle_type = (cl_external_mem_handle_type_khr*)malloc(handle_type_size);
+    handle_type = (cl_external_memory_handle_type_khr*)malloc(handle_type_size);
 
     errNum = clGetDeviceInfo(deviceID, CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR, handle_type_size, handle_type, NULL);
 
@@ -469,8 +470,8 @@ clExternalMemory::clExternalMemory(
                 log_info(" Opaque file descriptors are not supported on Windows\n");
                 fd = (int)deviceMemory->getHandle(externalMemoryHandleType);
                 err = check_external_memory_handle_type(devList[0], CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
-                extMemProperties.push_back((cl_mem_properties_khr)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
-                extMemProperties.push_back((cl_mem_properties_khr)fd);
+                extMemProperties.push_back((cl_mem_properties)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
+                extMemProperties.push_back((cl_mem_properties)fd);
                 break;
             case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_NT:
                 #ifndef _WIN32
@@ -479,8 +480,8 @@ clExternalMemory::clExternalMemory(
                 log_info(" Opaque NT handles are only supported on Windows\n");
                 handle = deviceMemory->getHandle(externalMemoryHandleType);
                 err = check_external_memory_handle_type(devList[0], CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR);
-                extMemProperties.push_back((cl_mem_properties_khr)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR);
-                extMemProperties.push_back((cl_mem_properties_khr)handle);
+                extMemProperties.push_back((cl_mem_properties)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR);
+                extMemProperties.push_back((cl_mem_properties)handle);
                 break;
             case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT:
                 #ifndef _WIN32
@@ -489,8 +490,8 @@ clExternalMemory::clExternalMemory(
                 log_info(" Opaque D3DKMT handles are only supported on Windows\n");
                 handle = deviceMemory->getHandle(externalMemoryHandleType);
                 err = check_external_memory_handle_type(devList[0], CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR);
-                extMemProperties.push_back((cl_mem_properties_khr)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR);
-                extMemProperties.push_back((cl_mem_properties_khr)handle);
+                extMemProperties.push_back((cl_mem_properties)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR);
+                extMemProperties.push_back((cl_mem_properties)handle);
                 break;
             default:
                  ASSERT(0);
@@ -501,9 +502,9 @@ clExternalMemory::clExternalMemory(
         throw std::runtime_error("Unsupported external memory type\n ");
     }
 
-    extMemProperties.push_back((cl_mem_properties_khr)CL_DEVICE_HANDLE_LIST_KHR);
-    extMemProperties.push_back((cl_mem_properties_khr)devList[0]);
-    extMemProperties.push_back((cl_mem_properties_khr)CL_DEVICE_HANDLE_LIST_END_KHR);
+    extMemProperties.push_back((cl_mem_properties)CL_DEVICE_HANDLE_LIST_KHR);
+    extMemProperties.push_back((cl_mem_properties)devList[0]);
+    extMemProperties.push_back((cl_mem_properties)CL_DEVICE_HANDLE_LIST_END_KHR);
     extMemProperties.push_back(0);
     
     m_externalMemory = clCreateBufferWithProperties(context, extMemProperties.data(), 1, size, NULL, &err);
@@ -524,7 +525,7 @@ clExternalMemoryImage::clExternalMemoryImage(
     cl_device_id deviceId)
 {
     cl_int errcode_ret = 0;    
-    std::vector<cl_mem_properties_khr> extMemProperties1;
+    std::vector<cl_mem_properties> extMemProperties1;
     cl_device_id devList[] = { deviceId, NULL };
 
     #ifdef _WIN32
@@ -543,23 +544,23 @@ clExternalMemoryImage::clExternalMemoryImage(
             log_info(" Opaque NT handles are only supported on Windows\n");
             handle = deviceMemory.getHandle(externalMemoryHandleType);
             errcode_ret = check_external_memory_handle_type(devList[0], CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR);
-            extMemProperties1.push_back((cl_mem_properties_khr)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR);
-            extMemProperties1.push_back((cl_mem_properties_khr)handle);
+            extMemProperties1.push_back((cl_mem_properties)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR);
+            extMemProperties1.push_back((cl_mem_properties)handle);
             break;
         case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT:
             log_info(" Opaque D3DKMT handles are only supported on Windows\n");
             handle = deviceMemory.getHandle(externalMemoryHandleType);
             errcode_ret = check_external_memory_handle_type(devList[0], CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR);
-            extMemProperties1.push_back((cl_mem_properties_khr)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR);
-            extMemProperties1.push_back((cl_mem_properties_khr)handle);
+            extMemProperties1.push_back((cl_mem_properties)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR);
+            extMemProperties1.push_back((cl_mem_properties)handle);
             break;
 #else
         case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD:
             log_info(" Opaque file descriptors are not supported on Windows\n");
             fd = (int)deviceMemory.getHandle(externalMemoryHandleType);
             errcode_ret = check_external_memory_handle_type(devList[0], CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
-            extMemProperties1.push_back((cl_mem_properties_khr)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
-            extMemProperties1.push_back((cl_mem_properties_khr)fd);
+            extMemProperties1.push_back((cl_mem_properties)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
+            extMemProperties1.push_back((cl_mem_properties)fd);
             break;
 #endif
         default:
@@ -582,9 +583,9 @@ clExternalMemoryImage::clExternalMemoryImage(
         throw std::runtime_error("getCLImageInfoFromVkImageInfo failed!!!");
     }
 
-    extMemProperties1.push_back((cl_mem_properties_khr)CL_DEVICE_HANDLE_LIST_KHR);
-    extMemProperties1.push_back((cl_mem_properties_khr)devList[0]);
-    extMemProperties1.push_back((cl_mem_properties_khr)CL_DEVICE_HANDLE_LIST_END_KHR);
+    extMemProperties1.push_back((cl_mem_properties)CL_DEVICE_HANDLE_LIST_KHR);
+    extMemProperties1.push_back((cl_mem_properties)devList[0]);
+    extMemProperties1.push_back((cl_mem_properties)CL_DEVICE_HANDLE_LIST_END_KHR);
     extMemProperties1.push_back(0);
     m_externalMemory = clCreateImageWithProperties(context,
                                                  extMemProperties1.data(),

--- a/test_conformance/vulkan/vulkan_interop_common/opencl_vulkan_wrapper.cpp
+++ b/test_conformance/vulkan/vulkan_interop_common/opencl_vulkan_wrapper.cpp
@@ -538,20 +538,8 @@ clExternalMemoryImage::clExternalMemoryImage(
     #endif
 
     switch (externalMemoryHandleType) {
-        case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD:
-            #ifdef _WIN32
-               ASSERT(0);
-            #endif
-            log_info(" Opaque file descriptors are not supported on Windows\n");
-            fd = (int)deviceMemory.getHandle(externalMemoryHandleType);
-            errcode_ret = check_external_memory_handle_type(devList[0], CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
-            extMemProperties1.push_back((cl_mem_properties_khr)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
-            extMemProperties1.push_back((cl_mem_properties_khr)fd);
-            break;
+#ifdef _WIN32
         case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_NT:
-            #ifndef _WIN32
-               ASSERT(0);
-            #endif
             log_info(" Opaque NT handles are only supported on Windows\n");
             handle = deviceMemory.getHandle(externalMemoryHandleType);
             errcode_ret = check_external_memory_handle_type(devList[0], CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR);
@@ -559,15 +547,21 @@ clExternalMemoryImage::clExternalMemoryImage(
             extMemProperties1.push_back((cl_mem_properties_khr)handle);
             break;
         case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT:
-            #ifndef _WIN32
-                ASSERT(0);
-            #endif
             log_info(" Opaque D3DKMT handles are only supported on Windows\n");
             handle = deviceMemory.getHandle(externalMemoryHandleType);
             errcode_ret = check_external_memory_handle_type(devList[0], CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR);
             extMemProperties1.push_back((cl_mem_properties_khr)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR);
             extMemProperties1.push_back((cl_mem_properties_khr)handle);
             break;
+#else
+        case VULKAN_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD:
+            log_info(" Opaque file descriptors are not supported on Windows\n");
+            fd = (int)deviceMemory.getHandle(externalMemoryHandleType);
+            errcode_ret = check_external_memory_handle_type(devList[0], CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
+            extMemProperties1.push_back((cl_mem_properties_khr)CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR);
+            extMemProperties1.push_back((cl_mem_properties_khr)fd);
+            break;
+#endif
         default:
             ASSERT(0);
             log_error("Unsupported external memory handle type\n");

--- a/test_conformance/vulkan/vulkan_interop_common/vulkan_utility.hpp
+++ b/test_conformance/vulkan/vulkan_interop_common/vulkan_utility.hpp
@@ -6,8 +6,7 @@
 #include <ostream>
 #include <string.h>
 #include <map>
-
-#define ARRAY_SIZE(a)  (sizeof(a) / sizeof(a[0]))
+#include "../../../test_common/harness/testHarness.h"
 
 #define STRING_(str)  #str
 #define STRING(str)   STRING_(str)


### PR DESCRIPTION
    Return type of getHandle is defined
    differently based on win or linux builds.
    Use appropriate guards when using API
    at other places.
    While at it remove duplicate definition
    of ARRAY_SIZE macro.
