### PR TITLE
Disable USE_GAS for Vulkan Loader build.

### DIFF
--- a/presubmit.sh
+++ b/presubmit.sh
@@ -58,7 +58,7 @@ cd Vulkan-Loader
 mkdir build
 cd build
 python3 ../scripts/update_deps.py
-cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} -DBUILD_WSI_XLIB_SUPPORT=OFF -DBUILD_WSI_XCB_SUPPORT=OFF -DBUILD_WSI_WAYLAND_SUPPORT=OFF -C helper.cmake ..
+cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} -DBUILD_WSI_XLIB_SUPPORT=OFF -DBUILD_WSI_XCB_SUPPORT=OFF -DBUILD_WSI_WAYLAND_SUPPORT=OFF -DUSE_GAS=OFF -C helper.cmake ..
 cmake --build . -j2 --config Release
 
 # Build CTS


### PR DESCRIPTION
Disable USE_GAS for Vulkan Loader build
to fix aarch64 build.